### PR TITLE
Fix empty state centering in table component

### DIFF
--- a/lib/live_table/table_component.ex
+++ b/lib/live_table/table_component.ex
@@ -208,7 +208,7 @@ defmodule LiveTable.TableComponent do
                     </tr>
                   </thead>
                   <tbody class="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-900">
-                    <tr class="only:table-row hidden">
+                    <tr id="empty-placeholder" class="only:table-row hidden">
                       <td colspan={length(@fields)} class="py-10 text-center">
                         <svg
                           class="mx-auto h-12 w-12 text-gray-400"

--- a/lib/live_table/table_component.ex
+++ b/lib/live_table/table_component.ex
@@ -46,7 +46,7 @@ defmodule LiveTable.TableComponent do
               <.exports formats={get_in(@table_options, [:exports, :formats])} />
             </div>
           </div>
-          
+
         <!-- Controls section -->
           <div class="mt-4">
             <.common_controls
@@ -127,7 +127,7 @@ defmodule LiveTable.TableComponent do
                     />
                   </div>
                 </div>
-                
+
         <!-- Per page -->
                 <select
                   :if={@options["pagination"]["paginate?"]}
@@ -141,7 +141,7 @@ defmodule LiveTable.TableComponent do
                   )}
                 </select>
               </div>
-              
+
         <!-- Filter toggle -->
               <button
                 :if={length(@filters) > 3}
@@ -159,7 +159,7 @@ defmodule LiveTable.TableComponent do
                 <span phx-update="ignore" id="filter-toggle-text">Filters</span>
               </button>
             </div>
-            
+
         <!-- Filters section -->
             <div
               id="filters-container"
@@ -208,7 +208,7 @@ defmodule LiveTable.TableComponent do
                     </tr>
                   </thead>
                   <tbody class="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-900">
-                    <tr class="only:block hidden">
+                    <tr class="only:table-row hidden">
                       <td colspan={length(@fields)} class="py-10 text-center">
                         <svg
                           class="mx-auto h-12 w-12 text-gray-400"


### PR DESCRIPTION
Changed from only:block to only:table-row to maintain proper table display structure

The empty row probably need support for dynamic id as per the documentation, as done for:  defp render_row(%{table_options: %{use_streams: true}} = var!(assigns)) ....

Docs: https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#stream/4

"It is important to set a unique ID on the empty row, otherwise it cannot be tracked in the stream container and subsequent patches will duplicate the node."

Maybe would be good to set custom empty state? Since you'd want different messages depending on what's being shown, but not necessarily want to change the custom content layout etc.

