### PR TITLE
fix: correct SQL syntax on limit

### DIFF
--- a/lib/live_table/paginate.ex
+++ b/lib/live_table/paginate.ex
@@ -14,9 +14,10 @@ defmodule LiveTable.Paginate do
     per_page = per_page |> String.to_integer()
 
     offset = max((page - 1) * per_page, 0)
+    limit = per_page + 1
 
     query
-    |> limit(^per_page + 1)
+    |> limit(^limit)
     |> offset(^offset)
   end
 end


### PR DESCRIPTION
I had the following error when trying to get the verification working with the minimal setup/install

```
(1064) You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '+ 1 OFFSET ?' at line 1

    query: SELECT m0.`id`, m0.`email` FROM `members` AS m0 ORDER BY m0.`id` LIMIT ? + 1 OFFSET ?
```

fixed by performing the addition in elixir rather than the query